### PR TITLE
fix #783 VSTO download link in Installer is outdated

### DIFF
--- a/vsto-redirect.html
+++ b/vsto-redirect.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>PowerPointLabs</title>
+<script>window.location = "http://www.microsoft.com/en-us/download/details.aspx?id=48217"
+</script>
+</head>
+<body>
+Re-directing to Microsoft Website...
+</body>
+</html>


### PR DESCRIPTION
Create a webpage to redirect to VSTO download page
