### PR TITLE
#95 Add a 'share' iconset to the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,3 +94,6 @@ title: PowerPointLabs
 	</div>
 </div>
 <script src="./js/index.js"></script>
+
+<!-- Go to www.addthis.com/dashboard to customize the tools -->
+<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-569e6c9f48acfaf7" async="async"></script>


### PR DESCRIPTION
Refer to PowerPointLabs/PowerPointLabs#95

The share icon set at the left was done by the widget from http://www.addthis.com/.

<img width="1273" alt="share function" src="https://cloud.githubusercontent.com/assets/13010884/12429191/e71f136c-bf23-11e5-9db3-801d407f78ed.png">
