### PR TITLE
Allow compressing of all images in /_site folder

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,5 @@ task default: %w[imageOptimize]
 
 task :imageOptimize do
   puts "Compressing images... Go grab a coffee!"
-  sh "image_optim -r --no-pngout --no-svgo ./_site/img"
+  sh "image_optim -r --no-pngout --no-svgo ./_site"
 end


### PR DESCRIPTION
### Problem
- There are images outside of _/img_ folder (_/gallery_ and _/shapes_) which doesn't get compressed automatically by rake task.
### Proposed Solution
- Allow compressing of images in the entire _/_site_ folder.
### Alternative Solution
- Move image folders outside of _/img_ into _/img_
- I didn't choose this solution as it requires changing of all links used in related HTML & CSS files.
- Since the image compression script only detects for image files, it is safe to run in the entire _/_site_ folder.

This PR is related to PowerPointLabs/PowerPointLabs#952. Thanks!
