### PR TITLE
User docs: order labs alphabetically #1093

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -1,14 +1,14 @@
 - Frequently Asked Questions
-- Highlight Lab
-- Picture Slides Lab
-- Animation Lab
-- Narrations Lab
-- Captions Lab
-- Zoom Lab
-- Crop Lab
-- Colors Lab
-- Shapes Lab
-- Effects Lab
 - Agenda Lab
+- Animation Lab
+- Captions Lab
+- Colors Lab
+- Crop Lab
+- Effects Lab
+- Highlight Lab
+- Narrations Lab
+- Picture Slides Lab
 - Resize Lab
+- Shapes Lab
 - Shortcuts Lab
+- Zoom Lab


### PR DESCRIPTION
Ordered labs alphabetically. FAQ is left as it is since there is a plan to move it to the navigation bar.

Fixes PowerPointLabs/PowerPointLabs#1093