### PR TITLE
#1651 Add Technical Troubleshooting FAQs to User Guide

### DIFF
--- a/_docs/faq.md
+++ b/_docs/faq.md
@@ -18,26 +18,5 @@ title: Frequently Asked Questions
 **Will PowerPointLabs work with my templates?**
 <br />Definitely! PowerPointLabs works fine with any PowerPoint template.
 
-**When I install PowerPointLabs, This message box shows up:**
-> “A corrupted system file is detected. 
-> In order to install our add-in, you may need to rename the file [VSTOInstaller.exe.Config] in the folder ... to the new filename [VSTOInstaller.exe.Config.backup]. 
-> However, in some PCs, the corrupted system file won't affect the installation. 
-> Click OK button to continue.”.
-
-**What should I do?**
-<br />You can click the OK button to proceed. If installation fails and installer shows any error message, you will need to install again, follow the instruction in the message box to rename the file [VSTOInstaller.exe.Config], and then continue installation.
-
-**After install, no PowerPointLabs ribbon appears?**
-<br />Restart PowerPoint, see if it appears. If not, follow these steps to re-activate PowerPointLabs:
-<br />1. In the PowerPoint application, click the **_File tab_** at the top left corner.
-<br />2. Click the **_Options_** button.
-<br />3. In the categories pane, click **_Add-ins_**.
-<br />4. In the **_Manage box_**, click **_Go_**.
-<br />5. **_Tick the checkbox_** for PowerPointLabs to enable it, click OK and restart PowerPoint.
-<br /><br />If it still does not work, follow these steps:
-<br />6. Open PowerPoint **_Options_**.
-<br />7. Click **_Trust Center_** (the last tab).
-<br />8. Click **_Trust Center Settings..._** button in the Trust Center tab. A Trust Center window will be open.
-<br />9. Click **_Add-ins tab_** in the **_Trust Center_** window
-<br />10. **_Uncheck all_** checkboxes in it.
-<br />11. After that, repeat step 1~5 to enable PowerPointLabs
+**What if I require technical support?**
+<br />Please refer to our [Technical Troubleshooting Guide](https://github.com/PowerPointLabs/PowerPointLabs/blob/master/doc/TechnicalFAQs.md) for possible solutions to technical issues.


### PR DESCRIPTION
There is a corresponding PR created in the main project.

The idea is to create a curated Technical Troubleshooting Guide in the main project page that the public AND future contributors can refer to. This helps to make solutions more accessible and improves workflow for future developers.

Furthermore the website faqs should be updated to remove duplicated instructions and link to the project technical troubleshooting guide. This PR fixes that

Note: the PR in the main project should be merged into `master` first before merging in this PR, so the link to the Technical Troubleshooting Guide would be valid