### PR TITLE
Updated website dev environment setup instructions and scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "therubyracer", "0.12.2"
-gem "jekyll", "3.1.6"
-gem "jekyll-less", "0.0.4"
-gem "redcarpet", "3.3.4"
-gem "html-proofer", "3.0.4"
-gem "image_optim", "0.22.1"
-gem "image_optim_pack", "0.2.1.20160221"
-gem "rake", "11.1.1"
+gem 'therubyracer', '0.12.3'
+gem 'jekyll', '3.8.5'
+gem 'jekyll-less', '0.0.4'
+gem 'redcarpet', '3.4.0'
+gem 'html-proofer', '3.10.1'
+gem 'image_optim', '0.26.3'
+gem 'image_optim_pack', '0.5.1.20190105'
+gem 'rake', '12.3.2'

--- a/README.md
+++ b/README.md
@@ -18,34 +18,34 @@ Interested to contribute? Please take a moment to review the [guidelines for con
 
 The website is generated using [Jekyll](http://www.jekyllrb.com). An easy way to get up and running is to just use [Vagrant](http://www.vagrantup.com) (which requires [VirtualBox](https://www.virtualbox.org)).
 
-> This README assumes no existing knowledge of how Vagrant (or Jekyll) works. In a nutshell, Vagrant is a nifty wrapper for a virtual machine (the "guest", running Ubuntu 14.04 in our case) which can be automatically setup with our project's dependencies, while letting us use our own familiar editors/tools on the "host".
+> This README assumes no existing knowledge of how Vagrant (or Jekyll) works. In a nutshell, Vagrant is a nifty wrapper for a virtual machine (the "guest", running Ubuntu 14.04.5 LTS in our case) which can be automatically setup with our project's dependencies, while letting us use our own familiar editors/tools on the "host".
 
 > Isn't it overkill to use Vagrant just for a simple Jekyll site? Maybe. It's been tricky to get running on Windows in the past, though, so this is perhaps in a strange way easier.
 
 [Fork](https://help.github.com/articles/fork-a-repo/) and clone the source codes from this repo.
-With Vagrant installed, `cd` into the project's root directory and run:
+With Vagrant and VirtualBox installed, `cd` into the project's root directory and run:
 
 ```shell
 $ vagrant up
 ```
 
-This starts up the virtual machine, installs Jekyll, and also installs the site's dependencies.
+This starts up the virtual machine, installs Jekyll, and also installs the site's dependencies. This might take a few minutes to complete.
 
 ### Development (with local previewing)
 
-To work on the site in the future (assuming the Vagrant box is still running - if not, run `vagrant up`):
+After the virtual machine has set up and the `vagrant up` command completed without errors, you are ready to work on the site through the virtual machine:
 
 ```shell
 $ vagrant ssh
-$ cd /vagrant
-$ jekyll s --host 0.0.0.0 --force_polling
+$ cd /pptlabs-website
+$ jekyll serve --host 0.0.0.0 --port 4000 --force_polling
 ```
 
-> `vagrant ssh` gives us an `ssh` session on the guest machine. `/vagrant` is a shared folder which maps to the project root on the host: this lets us modify the website's files in our editor of choice, and still have them accessible within the guest.
+> `vagrant ssh` gives us an `ssh` session on the guest machine. `/pptlabs-website` is a shared folder which maps to the project root on the host: this lets us modify the website's files in our editor of choice, and still have them accessible within the guest.
 
 The site should now be accessible on `localhost:4000` on the host, and can be modified with any changes automatically propagating to the guest (and visible after a quick refresh of the browser).
 
-> We need to force polling since Jekyll's normal method of checking for changes doesn't work with VirtualBox's shared folders. We also need to specify the host or the site will be served on the _guest_'s localhost instead, and won't be accessible from the host.
+> We need `--force_polling` since Jekyll's normal method of checking for changes doesn't work with VirtualBox's shared folders. We also need to specify the host or the site will be served on the _guest_'s localhost instead, and won't be accessible from the host.
 
 ### Building for Deployment
 
@@ -59,8 +59,9 @@ Nothing special here: `jekyll build` will output the site's files to `_site`. `r
 
 ```shell
 $ vagrant ssh
-$ cd /vagrant
-$ jekyll build; rake
+$ cd /pptlabs-website
+$ jekyll build
+$ rake
 ```
 
 If want to run the inline task only, do `rake inline`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,25 +1,25 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Provisioning script
-$script = <<SCRIPT
-sudo apt-get update -y
-sudo apt-get install make gcc nodejs -y
-sudo apt-get install build-essential g++ -y
-sudo apt-get install python-software-properties -y
-sudo apt-add-repository ppa:brightbox/ruby-ng
-sudo apt-get update -y
-sudo apt-get install ruby2.1 ruby2.1-dev ruby-switch -y
-sudo ruby-switch --set ruby2.1
-sudo apt-get install zlib1g-dev -y
-sudo gem install bundler
-su vagrant -c "cd /vagrant; bundle install"
-SCRIPT
+Vagrant::Config.run do |config|
 
-Vagrant.configure(2) do |config|
-	config.vm.network "forwarded_port", guest: 4000, host: 4000
+  config.vm.forward_port 4000, 4000
+  config.vm.provision :shell,
+    :inline => "sudo apt-get update -y && sudo apt-get install python-software-properties -y && sudo apt-add-repository -y ppa:rael-gc/rvm && sudo apt-get update && sudo apt-get -y install build-essential git"
+  config.vm.provision :shell,
+    path: "install-rvm.sh", args: "stable", privileged: false
+  config.vm.provision :shell,
+    path: "install-ruby.sh", args: "2.4.1", privileged: false
+  config.vm.provision :shell,
+    :inline => "gem install bundler --pre --no-ri --no-rdoc", privileged: false
+  config.vm.provision :shell,
+    :inline => "cd /pptlabs-website && bundle install", privileged: false
 
-	config.vm.box = "ubuntu/trusty64"
-	config.vm.provision "shell", inline: $script
+  config.ssh.forward_agent = true
+end
 
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.box_version = "20170818.0.0"
+  config.vm.synced_folder ".", "/pptlabs-website"
 end

--- a/_plugins/jekyll-less.rb
+++ b/_plugins/jekyll-less.rb
@@ -1,0 +1,3 @@
+require "jekyll-less"
+
+@@mtimes = {}

--- a/install-ruby.sh
+++ b/install-ruby.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+ source $HOME/.rvm/scripts/rvm || source /etc/profile.d/rvm.sh
+
+ rvm use --default --install $1
+
+ shift
+
+ if (( $# ))
+ then gem install $@
+ fi
+
+ rvm cleanup all
+ 

--- a/install-rvm.sh
+++ b/install-rvm.sh
@@ -1,0 +1,5 @@
+ #!/usr/bin/env bash
+
+ gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+ curl -sSL https://get.rvm.io | bash -s $1
+ 

--- a/script/cibuild
+++ b/script/cibuild
@@ -10,7 +10,7 @@ grep -o 'http://www.microsoft.com/[^"]*' ./vsto-redirect.html | xargs curl -s | 
     exit 2
 }
 
-curl -s 'http://www.comp.nus.edu.sg/~pptlabs/vsto-redirect.html' | grep -o 'http://www.microsoft.com/[^"]*' | xargs curl -s | grep -o -c "Visual Studio 2010 Tools for Office Runtime" || {
+curl -s 'https://www.comp.nus.edu.sg/~pptlabs/vsto-redirect.html' | grep -o 'http://www.microsoft.com/[^"]*' | xargs curl -s | grep -o -c "Visual Studio 2010 Tools for Office Runtime" || {
     echo "ERROR: fail to verify the VSTO runtime download link in the server. Please upload the correct version of vsto-redirect.html to the server."
     exit 2
 }


### PR DESCRIPTION
Fixes PowerPointLabs/PowerPointLabs#1743.

Dependencies have been updated to later versions, and the `Vagrantfile` used to install and boot up the VM has also been modified to work with these new dependencies.

I have also updated the `README` to show the updated instructions for setting up the website on a local machine.

I have tested this solution on both Windows 10 and MacOS (Mojave), both are working fine. 