### PR TITLE
#1883 Change link for github logo to PowerPointLabs Repo

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -11,6 +11,6 @@
     <li><a class="btn btn-link navbar-btn{% if page.url == '/terms-of-use.html' %} current{% endif %}" href="{{ site.baseurl }}/terms-of-use.html">Terms of Use</a></li>
     <li><a class="btn btn-link navbar-btn{% if page.url == '/review.html' %} current{% endif %}" href="{{ site.baseurl }}/review.html">Reviews</a></li>
     <li><a class="btn btn-link navbar-btn{% if page.url == '/contact.html' %} current{% endif %}" href="{{ site.baseurl }}/contact.html">About Us</a></li>
-    <li><a id="github-logo" href="https://github.com/PowerPointLabs/PowerPointLabs-Website" target="_blank"><img src="{{ site.baseurl }}/img/github-logo.png" width="25px" height="25px"/></a></li>
+    <li><a id="github-logo" href="https://github.com/PowerPointLabs/PowerPointLabs" target="_blank"><img src="{{ site.baseurl }}/img/github-logo.png" width="25px" height="25px"/></a></li>
   </ul>
 </nav>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -13,6 +13,6 @@
     <li><a class="btn btn-link navbar-btn{% if page.url == '/contact.html' %} current{% endif %}" href="{{ site.baseurl }}/contact.html">About Us</a></li>
   </ul>
   <ul class="navbar-right">
-    <li><a class="btn btn-link navbar-btn" href="https://github.com/PowerPointLabs/PowerPointLabs" target="_blank">GitHub &nbsp<img id="github-logo" src="{{ site.baseurl }}/img/github-logo.png"/></a></li>
+    <li><a class="btn btn-link navbar-btn" href="https://github.com/PowerPointLabs/PowerPointLabs" target="_blank">GitHub &nbsp;<img id="github-logo" src="{{ site.baseurl }}/img/github-logo.png"/></a></li>
   </ul>
 </nav>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -11,6 +11,8 @@
     <li><a class="btn btn-link navbar-btn{% if page.url == '/terms-of-use.html' %} current{% endif %}" href="{{ site.baseurl }}/terms-of-use.html">Terms of Use</a></li>
     <li><a class="btn btn-link navbar-btn{% if page.url == '/review.html' %} current{% endif %}" href="{{ site.baseurl }}/review.html">Reviews</a></li>
     <li><a class="btn btn-link navbar-btn{% if page.url == '/contact.html' %} current{% endif %}" href="{{ site.baseurl }}/contact.html">About Us</a></li>
-    <li><a id="github-logo" href="https://github.com/PowerPointLabs/PowerPointLabs" target="_blank"><img src="{{ site.baseurl }}/img/github-logo.png" width="25px" height="25px"/></a></li>
+  </ul>
+  <ul class="navbar-right">
+    <li><a class="btn btn-link navbar-btn" href="https://github.com/PowerPointLabs/PowerPointLabs" target="_blank">GitHub &nbsp<img id="github-logo" src="{{ site.baseurl }}/img/github-logo.png"/></a></li>
   </ul>
 </nav>

--- a/css/main.less
+++ b/css/main.less
@@ -201,6 +201,16 @@ a, .btn-link, .accent {
   display: inline-block;
 }
 
+.navbar-right {
+  margin-bottom: 0px;
+  padding-left: 0px;
+  padding-right: 5px;
+}
+
+.navbar-right > li {
+  display: inline-block;
+}
+
 .navbar-btn {
   margin: 0px;
   border: 0px;
@@ -433,12 +443,10 @@ a, .btn-link, .accent {
   color:#F0590F;
 }
 
-#github-logo:hover {
-  background-color: transparent;
-}
-
-#github-logo:focus {
-  background-color: transparent;
+#github-logo {
+  width:19px;
+  height:22px;
+  padding-bottom:3px;
 }
 
 blockquote {


### PR DESCRIPTION
Changed the link for github logo to [PowerPointLabs](https://github.com/PowerPointLabs/PowerPointLabs) instead of this repo

This PR also shifts the link to the right side of the navbar.